### PR TITLE
Added reward shaping for clean_up

### DIFF
--- a/baselines/wrappers/meltingpot_wrapper.py
+++ b/baselines/wrappers/meltingpot_wrapper.py
@@ -106,22 +106,7 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
           return True
       return False
 
-    def distanceToClosestApple(rgb):
-      # apple_coords = []
-      # for row in range(len(rgb)):
-      #   for col in range(len(rgb[0])):
-      #     if rgb[row][col].tolist() == APPLE:
-      #       apple_coords.append((row, col))
-
-      # nearest_dist = sys.maxsize
-      # for row, col in apple_coords:
-      #   print("\n\n\n\n\n\n\n")
-      #   dist = math.sqrt((col - 5) ** 2 + (row - 9) ** 2)
-      #   print(row, col, dist)
-      #   print("\n\n\n\n\n\n\n")
-      #   nearest_dist = min(dist, nearest_dist)
-      # return -1 if nearest_dist == sys.maxsize else nearest_dist
-      
+    def distanceToNearestApple(rgb):
       directions = ((0, 1), (1, 0), (0, -1), (-1, 0))
       queue = deque()
       queue.append((9, 5))
@@ -134,53 +119,51 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
           # print(row, col)
           if rgb[row][col].tolist() == APPLE:
             dist_to_nearest_apple = abs(col - 5) + abs(row - 9)
-            print("\n\n\n\n\n\n\n\n\n\n")
-            print(row, col, dist_to_nearest_apple, visited)
-            print("\n\n\n\n\n\n\n\n\n\n")
-            dist = "{:.6f}".format(dist_to_nearest_apple)
-            mapp = rgb
-            for v in visited:
-              mapp[v[0]][v[1]][0] += 20
-              mapp[v[0]][v[1]][1] += 20
-              mapp[v[0]][v[1]][2] += 20
-            plt.imshow(mapp)
-            plt.savefig(f"./img_out/{self.img_count}_{row}_{col}_{dist}.png")
-            self.img_count += 1 
-            return visited, row, col, dist_to_nearest_apple
+
+            ## DEBUG
+            # dist = "{:.6f}".format(dist_to_nearest_apple)
+            # mapp = rgb
+            # for v in visited:
+            #   mapp[v[0]][v[1]][0] += 20
+            #   mapp[v[0]][v[1]][1] += 20
+            #   mapp[v[0]][v[1]][2] += 20
+            # plt.imshow(mapp)
+            # plt.savefig(f"./img_out/{self.img_count}_{row}_{col}_{dist}.png")
+            # self.img_count += 1 
+
+            return dist_to_nearest_apple
           
           for d_row, d_col in directions:
             new_row = row + d_row
             new_col = col + d_col
             if new_row >= 0 and new_row < 11 and new_col >= 0 and new_col < 11:
               queue.append((row + d_row, col + d_col))
-      return None, 0, 0, -1
+      return -1
           
     def rewardFunc(action, observation):
       rgb = observation["RGB"]
+      dist_to_nearest_apple = distanceToNearestApple(rgb)
       should_clean = isDirtyWaterInRange(rgb)
+      if dist_to_nearest_apple != -1:
+        return 1 / dist_to_nearest_apple
+
       if should_clean:
         if action == FIRE_CLEAN:
           return 1
         else:
           return -1
       else:
-        return -0.25
+        return -0.1
 
     actions = [action_dict[agent_id] for agent_id in self._ordered_agent_ids]
     timestep = self._env.step(actions)
     observations = utils.timestep_to_observations(timestep)
 
     p0_r = rewardFunc(action_dict["player_0"], observations["player_0"])
-    v, r, c, dist = distanceToClosestApple(observations["player_0"]["RGB"])
-    # dist = "{:.6f}".format(dist)
-    # if dist != -1:
-    #   mapp = observations["player_0"]["RGB"]
-    #   for vv in v:
-    #     mapp[vv[0]][vv[1]][0] += 50
-    #   plt.imshow(mapp)
-    #   plt.savefig(f"./img_out/{self.img_count}_{r}_{c}_{dist}.png")
-    #   self.img_count += 1 
-  
+    p0_r = "{:.6f}".format(p0_r)
+    plt.imshow(observations["player_0"]["RGB"])
+    plt.savefig(f"./img_out/{self.img_count}_{p0_r}.png")
+    self.img_count += 1
     rewards = {
         agent_id: rewardFunc(action_dict[agent_id], observations[agent_id])
         for index, agent_id in enumerate(self._ordered_agent_ids)

--- a/baselines/wrappers/meltingpot_wrapper.py
+++ b/baselines/wrappers/meltingpot_wrapper.py
@@ -177,12 +177,12 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
     timestep = self._env.step(actions)
     observations = utils.timestep_to_observations(timestep)
 
-    # DEBUG: Visualize what player_0 is doing
-    p0_r = rewardFunc(action_dict["player_0"], observations["player_0"])
-    p0_r = "{:.6f}".format(p0_r)
-    plt.imshow(observations["player_0"]["RGB"])
-    plt.savefig(f"./img_out/{self.img_count}_{p0_r}.png")
-    self.img_count += 1
+    # # DEBUG: Visualize what player_0 is doing
+    # p0_r = rewardFunc(action_dict["player_0"], observations["player_0"])
+    # p0_r = "{:.6f}".format(p0_r)
+    # plt.imshow(observations["player_0"]["RGB"])
+    # plt.savefig(f"./img_out/{self.img_count}_{p0_r}.png")
+    # self.img_count += 1
   
     rewards = {
         agent_id: rewardFunc(action_dict[agent_id], observations[agent_id])

--- a/baselines/wrappers/meltingpot_wrapper.py
+++ b/baselines/wrappers/meltingpot_wrapper.py
@@ -48,6 +48,8 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
 
   def step(self, action_dict):
     """See base class."""
+
+    # CONSTANTS
     NOOP = 0
     FORWARD = 1
     BACKWARD = 2
@@ -71,20 +73,21 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
     }
 
     DIRTY_WATER = [28, 152, 147]
-    CLEANING_AREA = [
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
-      [0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
-      [0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]]
+    APPLE = [171, 153, 69]
+    CLEANING_AREA = (
+      (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+      (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+      (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+      (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+      (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+      (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+      (0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0),
+      (0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0),
+      (0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0),
+      (0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0),
+      (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
     
-    # @cache
+    @cache
     def generateCoordsFromBitmap(bitmap):
       coords = []
       for row in range(len(bitmap)):
@@ -118,6 +121,9 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
     p0_r = rewardFunc(action_dict["player_0"], observations["player_0"])
     plt.imshow(observations["player_0"]["RGB"])
     plt.savefig(f"./img_out/{self.img_count}_{p0_r}.png")
+    with open(f"./img_out/{self.img_count}_{p0_r}.json", "w") as outfile:
+        json_object = json.dumps(observations["player_0"]["RGB"].tolist(), indent=5)
+        outfile.write(json_object)
     self.img_count += 1 
   
     rewards = {
@@ -127,6 +133,8 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
     done = {'__all__': timestep.last()}
     info = {}
 
+
+    ###### START DEBUG LOGS ######
     debug_rewards = {
       agent_id: reward
       for agent_id, reward in rewards.items()
@@ -144,6 +152,7 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
       "observations": debug_observations
     }
     self.debug_out.append(debug)
+    ###### END DEBUG LOGS ######
     
     return observations, rewards, done, done, info
 

--- a/baselines/wrappers/meltingpot_wrapper.py
+++ b/baselines/wrappers/meltingpot_wrapper.py
@@ -21,7 +21,6 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
       env: dmlab2d environment to wrap. Will be closed when this wrapper closes.
     """
     self.debug_out = []
-    self.rgb_map = {}
     self.img_count = 0
     self._env = env
     self._num_players = len(self._env.observation_spec())
@@ -116,30 +115,17 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
     timestep = self._env.step(actions)
     observations = utils.timestep_to_observations(timestep)
 
-    # player_0_rgb = observations["player_0"]["RGB"]
-    # should_player_0_clean = isDirtyWaterInRange(player_0_rgb)
-    # if should_player_0_clean:
-    #   print("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n")
-    #   print("CLEAN!!!!!")
-    #   print("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n")
-    #   plt.imshow(player_0_rgb)
-    #   plt.show()
-
     p0_r = rewardFunc(action_dict["player_0"], observations["player_0"])
     plt.imshow(observations["player_0"]["RGB"])
     plt.savefig(f"./img_out/{self.img_count}_{p0_r}.png")
     self.img_count += 1 
+  
     rewards = {
         agent_id: rewardFunc(action_dict[agent_id], observations[agent_id])
         for index, agent_id in enumerate(self._ordered_agent_ids)
     }
     done = {'__all__': timestep.last()}
     info = {}
-
-    # for val in observations.values():
-    #   rgb = json.dumps(val['RGB'].tolist())
-    #   if rgb not in self.rgb_map:
-    #     self.rgb_map[rgb] = len(self.rgb_map)
 
     debug_rewards = {
       agent_id: reward
@@ -149,7 +135,6 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
       agent_id: {
         'COLLECTIVE_REWARD': val['COLLECTIVE_REWARD'],
         'READY_TO_SHOOT': val['READY_TO_SHOOT'].tolist(),
-        # 'RGB': self.rgb_map[json.dumps(val['RGB'].tolist())]
       }
       for agent_id, val in observations.items()
     }
@@ -169,10 +154,6 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
       with open("./my_debug_out.json", "w") as outfile:
           json_object = json.dumps(self.debug_out, indent=5)
           outfile.write(json_object)
-
-    with open("./rgb_mapping.json", "w") as outfile:
-        json_object = json.dumps(self.rgb_map, indent=5)
-        outfile.write(json_object)
     self._env.close()
 
   def get_dmlab2d_env(self):

--- a/baselines/wrappers/meltingpot_wrapper.py
+++ b/baselines/wrappers/meltingpot_wrapper.py
@@ -192,23 +192,23 @@ class MeltingPotEnv(multi_agent_env.MultiAgentEnv):
     info = {}
 
     ###### START DEBUG LOGS ######
-    debug_rewards = {
-      agent_id: reward
-      for agent_id, reward in rewards.items()
-    }
-    debug_observations = {
-      agent_id: {
-        'COLLECTIVE_REWARD': val['COLLECTIVE_REWARD'],
-        'READY_TO_SHOOT': val['READY_TO_SHOOT'].tolist(),
-      }
-      for agent_id, val in observations.items()
-    }
-    debug = {
-      "actions": list(map(lambda x: action_set[x], actions)),
-      "rewards": debug_rewards,
-      "observations": debug_observations
-    }
-    self.debug_out.append(debug)
+    # debug_rewards = {
+    #   agent_id: reward
+    #   for agent_id, reward in rewards.items()
+    # }
+    # debug_observations = {
+    #   agent_id: {
+    #     'COLLECTIVE_REWARD': val['COLLECTIVE_REWARD'],
+    #     'READY_TO_SHOOT': val['READY_TO_SHOOT'].tolist(),
+    #   }
+    #   for agent_id, val in observations.items()
+    # }
+    # debug = {
+    #   "actions": list(map(lambda x: action_set[x], actions)),
+    #   "rewards": debug_rewards,
+    #   "observations": debug_observations
+    # }
+    # self.debug_out.append(debug)
     ###### END DEBUG LOGS ######
     
     return observations, rewards, done, done, info


### PR DESCRIPTION
Policy:
- If there is at least one Apple in the agent's field of view, the Manhattan distance to the closest Apple is calculated and the agent is rewarded `1 / distance`. This is to encourage the agent to move towards Apples in sight.
- If there is at least one Dirty Water cell in the agent's cleaning area-of-effect, then the agent is rewarded `1` if they `FIRE_CLEAN`, and they are punished with `-1` if they do anything else. This is to encourage agents to clean whenever there is Dirty Water in front of them.
- Otherwise, the agent is punished with `-0.1` to encourage them to enter one of the above two cases